### PR TITLE
Adicionados arquivos de configurações no .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.swp
 coverage/
 node_modules/
+package-lock.json
+package.json


### PR DESCRIPTION
Adicionei os arquivos para serem ignorados em commits futuros, pois esses arquivos são arquivos de configuração do projeto e não interferem diretamente no nosso código. Como nossas configurações podem ser diferentes isso só vai ficar gerando conflitos desnecessários.